### PR TITLE
Record the triage label vocabulary for the engineering skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,10 @@ Be a **quirky friendly but critical peer reviewer**. Think of yourself as a quir
 
 Issues live in this repo's GitHub Issues, operated via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
+### Triage labels
+
+Default vocabulary: the five canonical role names are the label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`); categories are `bug` / `enhancement`. See `docs/agents/triage-labels.md`.
+
 ### Domain docs
 
 Single-context: `CONTEXT.md` at the repo root + ADRs in `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Category roles use GitHub's default labels: `bug` and `enhancement`. All seven labels exist on the GitHub repo (state labels created 2026-09-04).
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Add docs/agents/triage-labels.md mapping the five canonical triage roles (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix) to identically named GitHub labels, with bug/enhancement as the category labels, and link it from the CLAUDE.md "Agent skills" section. The labels were created on the GitHub repo on 2026-09-04 when the architecture-review issues (#66-#80) were triaged; without this file every /triage run asked for the mapping again.