### PR TITLE
train.py: import the trainer adapters at module top; drop the stale cycle comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/GovitPowerz/Aerocapture/actions/workflows/ci.yml/badge.svg)](https://github.com/GovitPowerz/Aerocapture/actions/workflows/ci.yml)
 
-Trajectory simulation and guidance optimization for aerocapture maneuvers, primarily targeting Mars Sample Return (MSR): a spacecraft enters the atmosphere at hyperbolic velocity and uses bank angle modulation to capture into a target orbit. A **Rust simulator** (validated to bit-level precision against a legacy reference implementation) with **Python training and analysis tools**: seven classical guidance schemes plus GA/PSO-trained neural guidance (dense, GRU, LSTM, Transformer, Mamba).
+Trajectory simulation and guidance optimization for aerocapture maneuvers, primarily targeting Mars Sample Return (MSR): a spacecraft enters the atmosphere at hyperbolic velocity and uses bank angle modulation to capture into a target orbit. A **Rust simulator** (validated to bit-level precision against a legacy reference implementation) with **Python training and analysis tools**: six classical guidance schemes plus GA/PSO-trained neural guidance (dense, GRU, LSTM, Transformer, Mamba).
 
 ![Correction-DV tail: classical guidance schemes vs trained neural guidance](articles/paper/figures/fig_classical_vs_nn.svg)
 
@@ -114,7 +114,7 @@ The simulation implements a full closed-loop GNC chain:
 
 ## Guidance Schemes
 
-Seven guidance algorithms, all trainable by the population optimizers below:
+Seven guidance schemes, all trainable by the population optimizers below:
 
 | Scheme | Description | Tunable params† | Notes |
 |---|---|---|---|

--- a/src/python/aerocapture/training/train.py
+++ b/src/python/aerocapture/training/train.py
@@ -36,6 +36,7 @@ from aerocapture.training.population import create_initial_population, create_nn
 from aerocapture.training.problem import AerocaptureProblem
 from aerocapture.training.reference import nominal_flight_overrides, piecewise_commanded_cos_bank, ref_trajectory_array
 from aerocapture.training.seed_curator import SeedCurator
+from aerocapture.training.trainer import IslandsTrainer, SingleAlgoTrainer
 
 _DEFAULT_PIECEWISE_N_SEGMENTS = 10
 
@@ -1324,10 +1325,6 @@ def train(
     )
 
     # The trainer seam: one loop contract, two adapters (see trainer.py).
-    # Imported lazily -- trainer.py imports this module's helpers at ITS top,
-    # so a module-level import here would be circular.
-    from aerocapture.training.trainer import IslandsTrainer, SingleAlgoTrainer  # noqa: PLC0415
-
     trainer: SingleAlgoTrainer | IslandsTrainer
     if config.optimizer.algorithm == "islands":
         trainer = IslandsTrainer(


### PR DESCRIPTION
**Stack position 3/11.** Review order follows the architecture-review index (#80). Built on `feature/readme-scheme-count`; until that predecessor merges, this PR's diff also shows its commits -- merge top-down with merge commits and each PR collapses to its own change.

The comment claimed trainer.py imports train helpers at its top, so the
adapter import had to be lazy. trainer.py only back-imports train inside
methods (and typing-only names under TYPE_CHECKING), so a module-level
import is safe in both import orders.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)