### PR TITLE
config.py: point the width comment at the real drift test; guard the constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/GovitPowerz/Aerocapture/actions/workflows/ci.yml/badge.svg)](https://github.com/GovitPowerz/Aerocapture/actions/workflows/ci.yml)
 
-Trajectory simulation and guidance optimization for aerocapture maneuvers, primarily targeting Mars Sample Return (MSR): a spacecraft enters the atmosphere at hyperbolic velocity and uses bank angle modulation to capture into a target orbit. A **Rust simulator** (validated to bit-level precision against a legacy reference implementation) with **Python training and analysis tools**: seven classical guidance schemes plus GA/PSO-trained neural guidance (dense, GRU, LSTM, Transformer, Mamba).
+Trajectory simulation and guidance optimization for aerocapture maneuvers, primarily targeting Mars Sample Return (MSR): a spacecraft enters the atmosphere at hyperbolic velocity and uses bank angle modulation to capture into a target orbit. A **Rust simulator** (validated to bit-level precision against a legacy reference implementation) with **Python training and analysis tools**: six classical guidance schemes plus GA/PSO-trained neural guidance (dense, GRU, LSTM, Transformer, Mamba).
 
 ![Correction-DV tail: classical guidance schemes vs trained neural guidance](articles/paper/figures/fig_classical_vs_nn.svg)
 
@@ -114,7 +114,7 @@ The simulation implements a full closed-loop GNC chain:
 
 ## Guidance Schemes
 
-Seven guidance algorithms, all trainable by the population optimizers below:
+Seven guidance schemes, all trainable by the population optimizers below:
 
 | Scheme | Description | Tunable params† | Notes |
 |---|---|---|---|

--- a/src/python/aerocapture/training/config.py
+++ b/src/python/aerocapture/training/config.py
@@ -15,11 +15,13 @@ import numpy.typing as npt
 from aerocapture.training.optimizer import OptimizerConfig
 
 # Candidate input vector width, mirroring the Rust `build_nn_input` /
-# `NN_FULL_INPUT_SIZE` contract (data/neural.rs). Currently 35 (16 baseline + 4
-# ref-traj + 1 exit-bank teacher + 4 lateral telemetry + 6 seam-free (sin,cos)
-# bank-history pairs at indices 25-30 + 1 periapsis_alt at 31 + 3
-# predicted_dv1/2/3 at indices 32-34). Single Python source of truth, imported
-# by warm_start.py and asserted against Rust by tests/test_nn_scale_parity.py.
+# `NN_FULL_INPUT_SIZE` contract (src/rust/src/data/neural/mod.rs). Currently 35
+# (16 baseline + 4 ref-traj + 1 exit-bank teacher + 4 lateral telemetry + 6
+# seam-free (sin,cos) bank-history pairs at indices 25-30 + 1 periapsis_alt at 31
+# + 3 predicted_dv1/2/3 at indices 32-34). Kept as a literal so this module
+# imports without the PyO3 extension (CI's pure-Python job); imported by
+# warm_start.py and asserted equal to `aerocapture_rs.NN_FULL_INPUT_SIZE` by
+# tests/test_record_index_drift.py::TestWidthDrift.
 _RUNTIME_CANDIDATE_WIDTH = 35
 
 

--- a/src/python/aerocapture/training/train.py
+++ b/src/python/aerocapture/training/train.py
@@ -36,6 +36,7 @@ from aerocapture.training.population import create_initial_population, create_nn
 from aerocapture.training.problem import AerocaptureProblem
 from aerocapture.training.reference import nominal_flight_overrides, piecewise_commanded_cos_bank, ref_trajectory_array
 from aerocapture.training.seed_curator import SeedCurator
+from aerocapture.training.trainer import IslandsTrainer, SingleAlgoTrainer
 
 _DEFAULT_PIECEWISE_N_SEGMENTS = 10
 
@@ -1324,10 +1325,6 @@ def train(
     )
 
     # The trainer seam: one loop contract, two adapters (see trainer.py).
-    # Imported lazily -- trainer.py imports this module's helpers at ITS top,
-    # so a module-level import here would be circular.
-    from aerocapture.training.trainer import IslandsTrainer, SingleAlgoTrainer  # noqa: PLC0415
-
     trainer: SingleAlgoTrainer | IslandsTrainer
     if config.optimizer.algorithm == "islands":
         trainer = IslandsTrainer(

--- a/tests/test_record_index_drift.py
+++ b/tests/test_record_index_drift.py
@@ -51,6 +51,13 @@ class TestWidthDrift:
         assert isinstance(aero.NN_FULL_INPUT_SIZE, int)
         assert aero.NN_FULL_INPUT_SIZE == 35
 
+    def test_runtime_candidate_width_matches_rust(self) -> None:
+        from aerocapture.training.config import _RUNTIME_CANDIDATE_WIDTH
+
+        assert _RUNTIME_CANDIDATE_WIDTH == aero.NN_FULL_INPUT_SIZE, (
+            f"config._RUNTIME_CANDIDATE_WIDTH == {_RUNTIME_CANDIDATE_WIDTH} but aerocapture_rs.NN_FULL_INPUT_SIZE == {aero.NN_FULL_INPUT_SIZE}"
+        )
+
     def test_module_exposes_dispersion_draw_len(self) -> None:
         assert isinstance(aero.DISPERSION_DRAW_LEN, int)
         assert aero.DISPERSION_DRAW_LEN == 26


### PR DESCRIPTION
**Stack position 4/11.** Review order follows the architecture-review index (#80). Built on `feature/train-import-comment`; until that predecessor merges, this PR's diff also shows its commits -- merge top-down with merge commits and each PR collapses to its own change.

The comment cited tests/test_nn_scale_parity.py, retired by the
2026-06-01 normalization design. The width-drift test now also asserts
_RUNTIME_CANDIDATE_WIDTH == aerocapture_rs.NN_FULL_INPUT_SIZE (it only
checked the ablation name list before).

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)