### PR TITLE
runner: one Monte Carlo fan-out; run options go into build_sim_state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,12 @@ src/rust/src/
     elements.rs                    — Orbital elements from state vector
     maneuver.rs                    — Delta-V cost computation (only called for confirmed captures)
   simulation/
-    runner.rs                      — Main sim loop: run() for CLI, run_for_api() for PyO3, run_for_api_with_draws() for external-draw API; dispatches between fixed Gill RK4 and adaptive DOPRI45
+    runner.rs                      — Main sim loop. ONE Monte Carlo fan-out, `run_core(config, data, draws, RunOptions)` (one run state per draw,
+                                     Rayon-parallel for >1 draw, each result stamped with its draw); the public entry points are draw-source adapters over it:
+                                     run() for CLI (draws from the config + photo/CSV output), run_for_api() for PyO3, run_for_api_with_draws() for the
+                                     external-draw API, run_for_api_cell() for one grid cell (`draw_from_seed`), run_single_collect() for the trace path.
+                                     `SimStateOptions` (photo / wall timeout / single-run banner) go INTO `build_sim_state`; nothing is poked onto a
+                                     `SimState` after construction; dispatches between fixed Gill RK4 and adaptive DOPRI45
                                        based on IntegrationMode; DOPRI45 mode uses `integrate_adaptive_with_events` (returns Vec<TriggeredEvent> for all events in a tick, processed chronologically)
                                        for sub-tick event detection (bounce, atmosphere exit, crash, phase transition) via dense output + Brent's root-finding (~1 ms precision); fixed RK4 uses legacy
                                        post-tick threshold checks (unchanged); tracks peak heat flux, g-load, dynamic pressure; NaN/Inf state termination (prevents infinite loops from extreme GA

--- a/src/rust/aerocapture-py/src/env.rs
+++ b/src/rust/aerocapture-py/src/env.rs
@@ -23,7 +23,7 @@ use aerocapture::simulation::final_record::{
     FR_HEAT_LOAD_MJM2,
 };
 use aerocapture::simulation::runner::{
-    SimState, TermReason, build_final_record, build_sim_state, ifinal_for,
+    SimState, SimStateOptions, TermReason, build_final_record, build_sim_state, ifinal_for,
 };
 
 use crate::config;
@@ -112,7 +112,13 @@ impl BatchedSimulation {
             let seed = seed_base + i as u64;
             let draw = sim_data.draw_from_seed(seed);
             let run_state = aerocapture::simulation::init::init_run_from_draw(&sim_data, &draw);
-            let state = build_sim_state(&sim_input, &sim_data, run_state, seed);
+            let state = build_sim_state(
+                &sim_input,
+                &sim_data,
+                run_state,
+                seed,
+                SimStateOptions::default(),
+            );
             envs.push(state);
             episode_ids.push(seed);
             episode_counter.push(i as u64);
@@ -160,7 +166,13 @@ impl BatchedSimulation {
             let draw = self.sim_data.draw_from_seed(seed);
             let run_state =
                 aerocapture::simulation::init::init_run_from_draw(&self.sim_data, &draw);
-            self.envs[i] = build_sim_state(&self.sim_input, &self.sim_data, run_state, seed);
+            self.envs[i] = build_sim_state(
+                &self.sim_input,
+                &self.sim_data,
+                run_state,
+                seed,
+                SimStateOptions::default(),
+            );
             self.episode_ids[i] = seed;
             self.step_counts[i] = 0;
             if !explicit_seeds {
@@ -272,7 +284,13 @@ impl BatchedSimulation {
                 let draw = self.sim_data.draw_from_seed(seed);
                 let run_state =
                     aerocapture::simulation::init::init_run_from_draw(&self.sim_data, &draw);
-                self.envs[i] = build_sim_state(&self.sim_input, &self.sim_data, run_state, seed);
+                self.envs[i] = build_sim_state(
+                    &self.sim_input,
+                    &self.sim_data,
+                    run_state,
+                    seed,
+                    SimStateOptions::default(),
+                );
                 self.episode_ids[i] = seed;
                 self.step_counts[i] = 0;
             } else {

--- a/src/rust/src/simulation/run_init.rs
+++ b/src/rust/src/simulation/run_init.rs
@@ -5,6 +5,7 @@
 //! simulation loop. Used by the CLI path (`runner::run_single`) and by
 //! `BatchedSimulation` to initialize and reset individual RL environments.
 
+use super::sim_types::SimStateOptions;
 use crate::config::SimInput;
 use crate::data::SimData;
 use crate::data::dispersions::NoiseSeeding;
@@ -50,6 +51,7 @@ pub fn build_sim_state(
     data: &SimData,
     run_state: init::RunState,
     env_idx: u64,
+    opts: SimStateOptions,
 ) -> SimState {
     let planet = &config.planet;
     let req = planet.equatorial_radius;
@@ -182,11 +184,11 @@ pub fn build_sim_state(
         max_time,
         exit_altitude,
         reference_bank_angle,
-        write_photo: false,
+        write_photo: opts.write_photo,
         sim_idx: env_idx as i32,
-        wall_timeout: None,
+        wall_timeout: opts.wall_timeout,
         wall_start: Instant::now(),
-        is_single: false,
+        is_single: opts.is_single,
     };
 
     // Prime last_nav so the RL env's reset() returns a valid initial observation

--- a/src/rust/src/simulation/runner.rs
+++ b/src/rust/src/simulation/runner.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 // resolving: `tick.rs`, `events.rs`, the `#[path]`-included test modules, and
 // the external `aerocapture-py` crate all reach these symbols via `runner::`.
 // Types are `pub` (aerocapture-py + events.rs consume them externally).
-pub use super::sim_types::{SimError, SimState, TermReason};
+pub use super::sim_types::{SimError, SimState, SimStateOptions, TermReason};
 // `DEG_TO_RAD` / `MIN_BOUNCE_ALT_FOR_CRASH_M` are both used inside this module
 // AND re-consumed by `tick.rs` via `runner::`, so the re-export is `pub(crate)`.
 // The remaining consts are used only inside this module's free functions.
@@ -129,45 +129,18 @@ struct SimResult {
     supervised_trace: Vec<(Vec<f64>, f64, f64, f64, f64)>,
 }
 
-/// Shared simulation orchestration: build run states, dispatch parallel/sequential runs.
-fn run_core(
-    config: &SimInput,
-    data: &SimData,
+/// Per-call switches for one fan-out: CLI photo output, trajectory capture, wall-clock cap.
+#[derive(Clone, Copy, Debug, Default)]
+struct RunOptions {
     write_photo: bool,
     include_trajectories: bool,
     wall_timeout: Option<Duration>,
-) -> Result<Vec<SimResult>, SimError> {
-    let n_sims = if config.n_sims == 0 { 1 } else { config.n_sims };
-    let is_mc = n_sims > 1;
+}
 
-    let draws = data.dispersion_config.as_ref().map(|dc| {
-        let draws = dc.generate_draws(n_sims as usize);
-        if write_photo {
-            let on_off = |b: bool| if b { "on" } else { "off" };
-            eprintln!(
-                "Monte Carlo: {} draws from seed {}, domains: state={} atmo={} aero={} nav={} mass={} vehicle={} pilot={} nav_filter={}",
-                draws.len(), dc.seed,
-                on_off(dc.initial_state.is_some()), on_off(dc.atmosphere.is_some()),
-                on_off(dc.aerodynamics.is_some()), on_off(dc.navigation.is_some()),
-                on_off(dc.mass.is_some()), on_off(dc.vehicle.is_some()),
-                on_off(dc.pilot.is_some()), on_off(dc.nav_filter.is_some()),
-            );
-        }
-        draws
-    });
-
-    let run_states: Vec<(init::RunState, [f64; DISPERSION_DRAW_LEN])> = (0..n_sims)
-        .map(|sim_idx| {
-            let draw = if let Some(ref d) = draws {
-                &d[sim_idx as usize]
-            } else {
-                &crate::data::dispersions::DispersionDraw::default()
-            };
-            (init::init_run_from_draw(data, draw), draw.to_array())
-        })
-        .collect();
-
-    let photo_sim_idx = if is_mc {
+/// Which sim gets the photo file in a Monte Carlo batch (`visualize_sim` is 1-based;
+/// default the last one); the only sim when there is just one.
+fn photo_sim_index(config: &SimInput, n_sims: i32) -> i32 {
+    if n_sims > 1 {
         if config.visualize_sim > 0 {
             (config.visualize_sim - 1).min(n_sims - 1)
         } else {
@@ -175,7 +148,68 @@ fn run_core(
         }
     } else {
         0
-    };
+    }
+}
+
+/// The draws a config asks for: `n_sims` from the dispersion config when present
+/// (announced on stderr for the CLI), else `n_sims` undispersed defaults.
+fn draws_from_config(
+    config: &SimInput,
+    data: &SimData,
+    announce: bool,
+) -> Vec<crate::data::dispersions::DispersionDraw> {
+    let n_sims = if config.n_sims == 0 { 1 } else { config.n_sims };
+    match data.dispersion_config.as_ref() {
+        Some(dc) => {
+            let draws = dc.generate_draws(n_sims as usize);
+            if announce {
+                let on_off = |b: bool| if b { "on" } else { "off" };
+                eprintln!(
+                    "Monte Carlo: {} draws from seed {}, domains: state={} atmo={} aero={} nav={} mass={} vehicle={} pilot={} nav_filter={}",
+                    draws.len(),
+                    dc.seed,
+                    on_off(dc.initial_state.is_some()),
+                    on_off(dc.atmosphere.is_some()),
+                    on_off(dc.aerodynamics.is_some()),
+                    on_off(dc.navigation.is_some()),
+                    on_off(dc.mass.is_some()),
+                    on_off(dc.vehicle.is_some()),
+                    on_off(dc.pilot.is_some()),
+                    on_off(dc.nav_filter.is_some()),
+                );
+            }
+            draws
+        }
+        None => vec![crate::data::dispersions::DispersionDraw::default(); n_sims as usize],
+    }
+}
+
+/// The one Monte Carlo fan-out: one run state per draw, Rayon-parallel when there is
+/// more than one draw, sequential otherwise, each result stamped with its draw.
+/// Every public entry point is a draw-source adapter over this function.
+fn run_core(
+    config: &SimInput,
+    data: &SimData,
+    draws: &[crate::data::dispersions::DispersionDraw],
+    opts: RunOptions,
+) -> Result<Vec<SimResult>, SimError> {
+    let RunOptions {
+        write_photo,
+        include_trajectories,
+        wall_timeout,
+    } = opts;
+    let n_sims = draws.len() as i32;
+    if n_sims == 0 {
+        return Ok(Vec::new());
+    }
+    let is_mc = n_sims > 1;
+
+    let run_states: Vec<(init::RunState, [f64; DISPERSION_DRAW_LEN])> = draws
+        .iter()
+        .map(|draw| (init::init_run_from_draw(data, draw), draw.to_array()))
+        .collect();
+
+    let photo_sim_idx = photo_sim_index(config, n_sims);
 
     if is_mc {
         let start = std::time::Instant::now();
@@ -226,21 +260,20 @@ fn run_core(
     }
 }
 
-/// Run the full simulation.
+/// Run the full simulation (CLI): draws from the config, photo + CSV output.
 pub fn run(config: &SimInput, data: &SimData) -> Result<(), SimError> {
-    let n_sims = if config.n_sims == 0 { 1 } else { config.n_sims };
-    let photo_sim_idx = if n_sims > 1 {
-        if config.visualize_sim > 0 {
-            (config.visualize_sim - 1).min(n_sims - 1)
-        } else {
-            n_sims - 1
-        }
-    } else {
-        0
+    let draws = draws_from_config(config, data, true);
+    let opts = RunOptions {
+        write_photo: true,
+        include_trajectories: false,
+        wall_timeout: None,
     };
-
-    let results = run_core(config, data, true, false, None)?;
-    write_csv_output(config, &results, photo_sim_idx)?;
+    let results = run_core(config, data, &draws, opts)?;
+    write_csv_output(
+        config,
+        &results,
+        photo_sim_index(config, draws.len() as i32),
+    )?;
     Ok(())
 }
 
@@ -304,9 +337,13 @@ pub fn run_for_api(
     include_trajectories: bool,
     wall_timeout: Option<Duration>,
 ) -> Result<Vec<crate::RunOutput>, SimError> {
-    let results = run_core(config, data, false, include_trajectories, wall_timeout)?;
-
-    Ok(results
+    let draws = draws_from_config(config, data, false);
+    let opts = RunOptions {
+        write_photo: false,
+        include_trajectories,
+        wall_timeout,
+    };
+    Ok(run_core(config, data, &draws, opts)?
         .into_iter()
         .map(|r| assemble_run_output(r, include_trajectories))
         .collect())
@@ -324,48 +361,12 @@ pub fn run_for_api_with_draws(
     include_trajectories: bool,
     wall_timeout: Option<Duration>,
 ) -> Result<Vec<crate::RunOutput>, SimError> {
-    let n = external_draws.len();
-    let is_mc = n > 1;
-
-    let run_states: Vec<(init::RunState, [f64; DISPERSION_DRAW_LEN])> = external_draws
-        .iter()
-        .map(|draw| (init::init_run_from_draw(data, draw), draw.to_array()))
-        .collect();
-
-    let results: Vec<SimResult> = if is_mc {
-        run_states
-            .par_iter()
-            .enumerate()
-            .map(|(idx, (run_state, disp_array))| {
-                let mut result = run_single(
-                    config,
-                    data,
-                    run_state,
-                    idx as i32,
-                    include_trajectories,
-                    wall_timeout,
-                )?;
-                result.dispersions = *disp_array;
-                Ok(result)
-            })
-            .collect::<Result<Vec<_>, _>>()?
-    } else if n == 1 {
-        let (run_state, disp_array) = &run_states[0];
-        let mut result = run_single(
-            config,
-            data,
-            run_state,
-            0,
-            include_trajectories,
-            wall_timeout,
-        )?;
-        result.dispersions = *disp_array;
-        vec![result]
-    } else {
-        return Ok(Vec::new());
+    let opts = RunOptions {
+        write_photo: false,
+        include_trajectories,
+        wall_timeout,
     };
-
-    Ok(results
+    Ok(run_core(config, data, &external_draws, opts)?
         .into_iter()
         .map(|r| assemble_run_output(r, include_trajectories))
         .collect())
@@ -386,16 +387,15 @@ pub fn run_for_api_cell(
     wall_timeout: Option<Duration>,
 ) -> Result<crate::RunOutput, SimError> {
     let draw = data.draw_from_seed(seed);
-    let run_state = init::init_run_from_draw(data, &draw);
-    let mut result = run_single(
-        config,
-        data,
-        &run_state,
-        0,
+    let opts = RunOptions {
+        write_photo: false,
         include_trajectories,
         wall_timeout,
-    )?;
-    result.dispersions = draw.to_array();
+    };
+    let mut results = run_core(config, data, std::slice::from_ref(&draw), opts)?;
+    let result = results
+        .pop()
+        .expect("run_core returns exactly one result for one draw");
     Ok(assemble_run_output(result, include_trajectories))
 }
 
@@ -538,13 +538,12 @@ fn run_single(
     // derivation, GNC init, and bias-mode last_nav priming as the RL env path);
     // `sim_idx as u64` reproduces the historical per-sim seeds exactly:
     // EKF `random_seed + sim_idx*10_000`, GM-RNG `... + 0xDE45`.
-    let mut sim_state = build_sim_state(config, data, *run_state, sim_idx as u64);
-
-    // CLI-specific overrides not produced by `build_sim_state` (which targets the
-    // RL env defaults: no photo, no wall timeout, not the single-run banner).
-    sim_state.write_photo = write_photo;
-    sim_state.wall_timeout = wall_timeout;
-    sim_state.is_single = config.n_sims <= 1 && config.screen_output;
+    let opts = SimStateOptions {
+        write_photo,
+        wall_timeout,
+        is_single: config.n_sims <= 1 && config.screen_output,
+    };
+    let mut sim_state = build_sim_state(config, data, *run_state, sim_idx as u64, opts);
     let is_single = sim_state.is_single;
 
     // Event detection setup (used by adaptive integrator)
@@ -699,9 +698,13 @@ pub fn run_single_collect(
     data: &SimData,
 ) -> Result<[f64; FINAL_RECORD_LEN], SimError> {
     let draw = crate::data::dispersions::DispersionDraw::default();
-    let run_state = init::init_run_from_draw(data, &draw);
-    let result = run_single(config, data, &run_state, 0, false, None)?;
-    Ok(result.final_line)
+    let mut results = run_core(
+        config,
+        data,
+        std::slice::from_ref(&draw),
+        RunOptions::default(),
+    )?;
+    Ok(results.pop().expect("one draw, one result").final_line)
 }
 
 /// Build a photo snapshot line.

--- a/src/rust/src/simulation/sim_types.rs
+++ b/src/rust/src/simulation/sim_types.rs
@@ -72,6 +72,16 @@ impl fmt::Display for SimError {
 
 impl std::error::Error for SimError {}
 
+/// Per-run switches that vary by entry point: CLI photo output, the API's per-sim
+/// wall-clock cap, and the single-run console banner. The RL env and the grid cell
+/// use `default()` (no photo, no cap, no banner).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SimStateOptions {
+    pub write_photo: bool,
+    pub wall_timeout: Option<Duration>,
+    pub is_single: bool,
+}
+
 /// Simulation state — mutable per-tick data plus pre-loop constants.
 ///
 /// Expanded to include all mutable loop-local variables from `run_single` so that

--- a/src/rust/tests/env_equivalence.rs
+++ b/src/rust/tests/env_equivalence.rs
@@ -12,6 +12,7 @@ mod common;
 use aerocapture::config::SimInput;
 use aerocapture::data::SimData;
 use aerocapture::data::dispersions::DispersionDraw;
+use aerocapture::simulation::runner::SimStateOptions;
 use aerocapture::simulation::{init, runner, tick};
 
 fn load() -> (SimInput, SimData) {
@@ -45,7 +46,8 @@ fn step_matches_run_single_collect_reference_trajectory() {
     let planet = config.planet.clone();
     let draw = DispersionDraw::default();
     let run_state = init::init_run_from_draw(&data, &draw);
-    let mut state = runner::build_sim_state(&config, &data, run_state, 0);
+    let mut state =
+        runner::build_sim_state(&config, &data, run_state, 0, SimStateOptions::default());
 
     let event_defs = runner::build_event_defs();
     let event_ctx = runner::build_event_ctx(&config, &data);

--- a/src/rust/tests/env_properties.rs
+++ b/src/rust/tests/env_properties.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use aerocapture::simulation::runner::SimStateOptions;
 use proptest::prelude::*;
 
 use aerocapture::config::SimInput;
@@ -45,7 +46,7 @@ proptest! {
         // RNG seeding path still exercises the build_sim_state init code.
         let draw = DispersionDraw::default();
         let run_state = init::init_run_from_draw(&data, &draw);
-        let mut state = runner::build_sim_state(&config, &data, run_state, seed);
+        let mut state = runner::build_sim_state(&config, &data, run_state, seed, SimStateOptions::default());
 
         let event_defs = runner::build_event_defs();
         let event_ctx = runner::build_event_ctx(&config, &data);

--- a/src/rust/tests/test_batched_simulation_nn_state.rs
+++ b/src/rust/tests/test_batched_simulation_nn_state.rs
@@ -11,6 +11,7 @@ use aerocapture::config::SimInput;
 use aerocapture::data::SimData;
 use aerocapture::data::dispersions::DispersionDraw;
 use aerocapture::simulation::init;
+use aerocapture::simulation::runner::SimStateOptions;
 use aerocapture::simulation::runner::build_sim_state;
 
 #[test]
@@ -30,8 +31,8 @@ fn guidance_state_nn_state_is_per_env() {
     let run_state_0 = init::init_run_from_draw(&data, &draw);
     let run_state_1 = init::init_run_from_draw(&data, &draw);
 
-    let s0 = build_sim_state(&config, &data, run_state_0, 0);
-    let s1 = build_sim_state(&config, &data, run_state_1, 1);
+    let s0 = build_sim_state(&config, &data, run_state_0, 0, SimStateOptions::default());
+    let s1 = build_sim_state(&config, &data, run_state_1, 1, SimStateOptions::default());
 
     assert!(
         s0.guidance_state.nn_state.is_some(),

--- a/src/rust/tests/test_forced_bank_telemetry.rs
+++ b/src/rust/tests/test_forced_bank_telemetry.rs
@@ -10,7 +10,9 @@ use aerocapture::config::SimInput;
 use aerocapture::data::SimData;
 use aerocapture::data::dispersions::DispersionDraw;
 use aerocapture::simulation::init;
-use aerocapture::simulation::runner::{build_event_ctx, build_event_defs, build_sim_state};
+use aerocapture::simulation::runner::{
+    SimStateOptions, build_event_ctx, build_event_defs, build_sim_state,
+};
 use aerocapture::simulation::tick::step_one_tick;
 
 #[test]
@@ -23,7 +25,7 @@ fn forced_bank_drives_nn_telemetry() {
 
     let draw = DispersionDraw::default();
     let run_state = init::init_run_from_draw(&data, &draw);
-    let mut state = build_sim_state(&config, &data, run_state, 0);
+    let mut state = build_sim_state(&config, &data, run_state, 0, SimStateOptions::default());
     let event_defs = build_event_defs();
     let event_ctx = build_event_ctx(&config, &data);
 


### PR DESCRIPTION
**Stack position 10/11.** Review order follows the architecture-review index (#80). Built on `feature/front-door-docs`; until that predecessor merges, this PR's diff also shows its commits -- merge top-down with merge commits and each PR collapses to its own change.

The draw -> run state -> parallel/sequential run -> stamp-dispersions
sequence was written three times (run_core, run_for_api_with_draws,
run_for_api_cell) and the single-run path poked write_photo /
wall_timeout / is_single onto the SimState after construction.

run_core(config, data, draws, RunOptions) is now the only fan-out; run(),
run_for_api(), run_for_api_with_draws(), run_for_api_cell() and
run_single_collect() are draw-source adapters over it (draws_from_config,
the caller's draws, draw_from_seed, one default draw). SimStateOptions
(photo, wall timeout, single-run banner) is a constructor argument of
build_sim_state; the RL env and the Rust env tests pass default().
Photo-sim choice, draw order, the Rayon-vs-sequential decision and the CLI
banners are unchanged.

Gates: 653 Rust tests incl. the six guidance goldens, PyO3-vs-CLI
bit-identity, run_grid bit-identity, run_with_draws echo; fast Python suite.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)