### PR TITLE
CLAUDE.md: re-wrap the one line the #79 sync pushed past 200 bytes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,8 @@ src/rust/src/
                                        `[network.normalization]` / the `DEFAULT_NORMALIZATION` table (`data/neural.rs`); data-driven via `calibrate_inputs.py`. The TOML override is ALSO carried on
                                        `SimData::nn_normalization_override` (populated regardless of guidance type), so the `collect_supervised` trace -- a teacher scheme with NO NN model loaded --
                                        normalizes on the same scales the deployed NN uses, avoiding a warm-start train/inference mismatch (`build_nn_input` precedence: loaded model > SimData override
-                                       > DEFAULT). Ablation support via ablated_input); `nn_bank_angle(nav, nn, &mut NnState, data, planet, &NnInputContext)` -- `NnInputContext::from_guidance_state(&GuidanceState,
+                                       > DEFAULT). Ablation support via ablated_input); `nn_bank_angle(nav, nn, &mut NnState, data, planet, &NnInputContext)` --
+                                       `NnInputContext::from_guidance_state(&GuidanceState,
                                                                                                                                                                  sim_time, target_inclination)` is the
                                                                                                                                                                  ONE place the previous-tick telemetry
                                                                                                                                                                  (inputs 21-24, the (sin,cos) history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,21 @@ src/rust/src/
                                        `[network.normalization]` / the `DEFAULT_NORMALIZATION` table (`data/neural.rs`); data-driven via `calibrate_inputs.py`. The TOML override is ALSO carried on
                                        `SimData::nn_normalization_override` (populated regardless of guidance type), so the `collect_supervised` trace -- a teacher scheme with NO NN model loaded --
                                        normalizes on the same scales the deployed NN uses, avoiding a warm-start train/inference mismatch (`build_nn_input` precedence: loaded model > SimData override
-                                       > DEFAULT). Ablation support via ablated_input); `nn_bank_angle(nav, nn, &mut NnState, ..., prev_inclination_error, prev_bank_signed, time_since_last_sign_flip,
-                                       inclination_error_integral, prev_realized_bank)` threads stateful layer state from GuidanceState (Phase 0 dense-only; Phase 1+ adds Gru/Lstm/Attention/Ssm).
+                                       > DEFAULT). Ablation support via ablated_input); `nn_bank_angle(nav, nn, &mut NnState, data, planet, &NnInputContext)` -- `NnInputContext::from_guidance_state(&GuidanceState,
+                                                                                                                                                                 sim_time, target_inclination)` is the
+                                                                                                                                                                 ONE place the previous-tick telemetry
+                                                                                                                                                                 (inputs 21-24, the (sin,cos) history
+                                                                                                                                                                 pairs, the `delta` decoder base, the
+                                                                                                                                                                 sign-flip age) is read;
+                                                                                                                                                                 `build_nn_input(nav, NnModelView {
+                                                                                                                                                                 input_mask, ablated_input,
+                                                                                                                                                                 ablated_value }, data, planet, &ctx)`
+                                                                                                                                                                 takes the same context (dispatch, the
+                                                                                                                                                                 supervised trace in tick.rs, and the RL
+                                                                                                                                                                 env all build it with that constructor)
+                                                                                                                                                                 threads stateful layer state from
+                                                                                                                                                                 GuidanceState (Phase 0 dense-only;
+                                                                                                                                                                 Phase 1+ adds Gru/Lstm/Attention/Ssm).
                                        Path-A `mode = "magnitude_only"` (dispatched in dispatch.rs via NeuralNetMode) routes the NN's `.abs()`'d output through FTC's unsigned-magnitude pipeline (exit
                                        + lateral + thermal_limiter) instead of bypassing them.
       equilibrium_glide.rs         — Equilibrium glide with hdot damping + velocity bias; lift uses the nav-filtered density (`nav.density_guidance` = onboard model x estimated dispersion factor),

--- a/src/rust/aerocapture-py/src/env.rs
+++ b/src/rust/aerocapture-py/src/env.rs
@@ -6,6 +6,7 @@
 //!
 //! step() is implemented in Task 1.4.
 
+use aerocapture::gnc::guidance::neural::{NnInputContext, NnModelView, build_nn_input};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -392,29 +393,16 @@ impl BatchedSimulation {
 fn build_obs_for_env(state: &SimState, data: &Arc<SimData>, config: &SimInput) -> Vec<f64> {
     let nav = state.last_nav_output();
     let planet = &config.planet;
-    let target_inclination = data.target_orbit.inclination;
-    let ref_velocity_latched = state.guidance_state.reference_velocity;
     let nn = data
         .neural_net
         .as_ref()
         .expect("invariant: neural_net validated in BatchedSimulation::new");
-
-    let time_since_flip = state.sim_time() - state.guidance_state.last_sign_flip_time_for_nn;
-    aerocapture::gnc::guidance::neural::build_nn_input(
-        &nav,
-        nn.input_mask.as_deref(),
-        nn.ablated_input,
-        nn.ablated_value,
-        data,
-        planet,
-        target_inclination,
-        ref_velocity_latched,
-        state.guidance_state.prev_inclination_error_for_nn,
-        state.guidance_state.prev_bank_for_nn,
-        time_since_flip,
-        state.guidance_state.inclination_error_integral,
-        state.guidance_state.prev_realized_bank_for_nn,
-    )
+    let ctx = NnInputContext::from_guidance_state(
+        &state.guidance_state,
+        state.sim_time(),
+        data.target_orbit.inclination,
+    );
+    build_nn_input(&nav, NnModelView::of(nn), data, planet, &ctx)
 }
 
 /// Predicted correction delta-v [dv1, dv2, dv3] (raw m/s) on the current

--- a/src/rust/src/gnc/guidance/dispatch.rs
+++ b/src/rust/src/gnc/guidance/dispatch.rs
@@ -237,31 +237,17 @@ pub fn guidance_step(
                     // fresh zeroed state every guidance tick.
                     state.nn_state = Some(NnState::for_model(nn));
                 }
-                // Snapshot telemetry scalars BEFORE the mut borrow of nn_state so
-                // rustc doesn't trip on simultaneous shared+mut borrows of `state`.
-                let prev_incl_err = state.prev_inclination_error_for_nn;
-                let prev_bank = state.prev_bank_for_nn;
-                let time_since_flip = sim_time - state.last_sign_flip_time_for_nn;
-                let integral = state.inclination_error_integral;
-                let ref_vel = state.reference_velocity;
-                let prev_realized = state.prev_realized_bank_for_nn;
+                // Snapshot the telemetry context (Copy) BEFORE the mut borrow of
+                // nn_state so rustc doesn't trip on shared+mut borrows of `state`.
+                let ctx = neural::NnInputContext::from_guidance_state(
+                    state,
+                    sim_time,
+                    data.target_orbit.inclination,
+                );
                 let nn_state = state.nn_state.as_mut().expect(
                     "neural_network scheme requires nn_state initialized by GuidanceState::new",
                 );
-                let signed = neural::nn_bank_angle(
-                    nav,
-                    nn,
-                    nn_state,
-                    data,
-                    planet,
-                    data.target_orbit.inclination,
-                    ref_vel,
-                    prev_incl_err,
-                    prev_bank,
-                    time_since_flip,
-                    integral,
-                    prev_realized,
-                );
+                let signed = neural::nn_bank_angle(nav, nn, nn_state, data, planet, &ctx);
                 // MagnitudeOnly: drop the sign and feed magnitude into the unsigned
                 // pipeline (thermal limiter + lateral guidance handle sign + safety).
                 if data.guidance.neural_mode == NeuralNetMode::MagnitudeOnly {

--- a/src/rust/src/gnc/guidance/neural.rs
+++ b/src/rust/src/gnc/guidance/neural.rs
@@ -43,6 +43,7 @@
 //! - `Delta`: 1 tanh output; `bank = wrap_to_pi(prev_realized + delta_max * out[0]) ∈ (-π, π]`.
 //!   Only legal in `full_neural` mode.
 
+use super::dispatch::GuidanceState;
 use crate::config::PlanetConfig;
 use crate::data::SimData;
 use crate::data::neural::{NN_FULL_INPUT_SIZE, NeuralNetModel};
@@ -71,22 +72,88 @@ use crate::orbit::{elements, maneuver};
 /// `prev_realized_bank` (radians) is the pilot-realized bank angle from the
 /// PREVIOUS tick. It populates indices 29-30 as a (sin, cos) pair and also
 /// serves as the base for the `Delta` output decoder in `nn_bank_angle`.
-#[allow(clippy::too_many_arguments)]
+/// Telemetry the candidate inputs need beyond the navigation output: the target
+/// inclination and the previous-tick guidance state that makes the signed-bank
+/// decision Markovian (inputs 20-31, and the base of the `delta` decoder).
+/// Built once per tick from `GuidanceState` by `from_guidance_state`; the
+/// runtime callers (dispatch, the supervised trace, the RL env) all go through
+/// that constructor so the sign-flip age is computed in exactly one place.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NnInputContext {
+    /// Target orbit inclination (rad).
+    pub target_inclination: f64,
+    /// Exit-phase latched reference velocity (0.0 pre-bounce).
+    pub ref_velocity_latched: f64,
+    /// Previous tick's inclination error (rad); `None` on the first tick.
+    pub prev_inclination_error: Option<f64>,
+    /// Previous tick's commanded bank (rad, signed).
+    pub prev_bank_signed: f64,
+    /// Seconds since the last bank-sign flip.
+    pub time_since_last_sign_flip: f64,
+    /// Running inclination-error integral (rad*s).
+    pub inclination_error_integral: f64,
+    /// Previous tick's pilot-realized bank (rad).
+    pub prev_realized_bank: f64,
+}
+
+impl NnInputContext {
+    /// The context for this tick, from the guidance state as it was at the END of
+    /// the previous tick (tick.rs updates the telemetry fields post-guidance).
+    pub fn from_guidance_state(gs: &GuidanceState, sim_time: f64, target_inclination: f64) -> Self {
+        Self {
+            target_inclination,
+            ref_velocity_latched: gs.reference_velocity,
+            prev_inclination_error: gs.prev_inclination_error_for_nn,
+            prev_bank_signed: gs.prev_bank_for_nn,
+            time_since_last_sign_flip: sim_time - gs.last_sign_flip_time_for_nn,
+            inclination_error_integral: gs.inclination_error_integral,
+            prev_realized_bank: gs.prev_realized_bank_for_nn,
+        }
+    }
+}
+
+/// Which candidate inputs a model consumes and how one of them is ablated.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NnModelView<'a> {
+    /// Indices into the 35-wide candidate vector; `None` = the first 16 (legacy).
+    pub input_mask: Option<&'a [usize]>,
+    /// Candidate index frozen to `ablated_value` (ablation studies).
+    pub ablated_input: Option<usize>,
+    pub ablated_value: f64,
+}
+
+impl NnModelView<'_> {
+    /// The view a loaded model declares.
+    pub fn of(nn: &NeuralNetModel) -> NnModelView<'_> {
+        NnModelView {
+            input_mask: nn.input_mask.as_deref(),
+            ablated_input: nn.ablated_input,
+            ablated_value: nn.ablated_value,
+        }
+    }
+}
+
 pub fn build_nn_input(
     nav: &NavigationOutput,
-    input_mask: Option<&[usize]>,
-    ablated_input: Option<usize>,
-    ablated_value: f64,
+    view: NnModelView<'_>,
     data: &SimData,
     planet: &PlanetConfig,
-    target_inclination: f64,
-    ref_velocity_latched: f64,
-    prev_inclination_error: Option<f64>,
-    prev_bank_signed: f64,
-    time_since_last_sign_flip: f64,
-    inclination_error_integral: f64,
-    prev_realized_bank: f64,
+    ctx: &NnInputContext,
 ) -> Vec<f64> {
+    let NnModelView {
+        input_mask,
+        ablated_input,
+        ablated_value,
+    } = view;
+    let NnInputContext {
+        target_inclination,
+        ref_velocity_latched,
+        prev_inclination_error,
+        prev_bank_signed,
+        time_since_last_sign_flip,
+        inclination_error_integral,
+        prev_realized_bank,
+    } = *ctx;
     let mu = planet.mu;
 
     // Radial velocity: V * sin(gamma)
@@ -236,43 +303,19 @@ pub fn build_nn_input(
 /// Returns the **signed** bank angle in radians.
 /// Lateral guidance is bypassed for this scheme -- the NN controls roll direction directly.
 ///
-/// `prev_inclination_error`, `prev_bank_signed`, `time_since_last_sign_flip`, and
-/// `inclination_error_integral` are pulled from GuidanceState by the caller
-/// (dispatch.rs) and populate input indices 21-24 -- see build_nn_input.
-///
-/// `prev_realized_bank` (radians) is the pilot-realized bank angle from the
-/// PREVIOUS tick. Populates input indices 29-30 and serves as the base for
-/// the `Delta` output decoder.
-#[allow(clippy::too_many_arguments)]
+/// `ctx` carries the previous-tick telemetry (inputs 21-24, the (sin,cos) history
+/// pairs, and `prev_realized_bank`, the base of the `Delta` decoder); build it
+/// with `NnInputContext::from_guidance_state`.
 pub fn nn_bank_angle(
     nav: &NavigationOutput,
     nn: &NeuralNetModel,
     nn_state: &mut NnState,
     data: &SimData,
     planet: &PlanetConfig,
-    target_inclination: f64, // radians
-    ref_velocity_latched: f64,
-    prev_inclination_error: Option<f64>,
-    prev_bank_signed: f64,
-    time_since_last_sign_flip: f64,
-    inclination_error_integral: f64,
-    prev_realized_bank: f64,
+    ctx: &NnInputContext,
 ) -> f64 {
-    let masked = build_nn_input(
-        nav,
-        nn.input_mask.as_deref(),
-        nn.ablated_input,
-        nn.ablated_value,
-        data,
-        planet,
-        target_inclination,
-        ref_velocity_latched,
-        prev_inclination_error,
-        prev_bank_signed,
-        time_since_last_sign_flip,
-        inclination_error_integral,
-        prev_realized_bank,
-    );
+    let masked = build_nn_input(nav, NnModelView::of(nn), data, planet, ctx);
+    let prev_realized_bank = ctx.prev_realized_bank;
     use crate::data::neural::OutputParam;
     use crate::gnc::control::angle_utils::wrap_to_pi;
     use std::f64::consts::PI;
@@ -460,18 +503,22 @@ mod tests {
         let full_mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let inp = build_nn_input(
             &nav,
-            Some(&full_mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&full_mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         assert_eq!(inp.len(), 35, "candidate vector must be 35 wide");
     }
@@ -503,18 +550,22 @@ mod tests {
         let full_mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let inp = build_nn_input(
             &nav,
-            Some(&full_mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&full_mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         let expected_dv2 = apply_norm(0.0, &DEFAULT_NORMALIZATION[33]); // asinh(0) = 0
         assert!(
@@ -554,18 +605,22 @@ mod tests {
         let full_mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let inp = build_nn_input(
             &nav,
-            Some(&full_mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&full_mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         assert!((inp[32] - apply_norm(dv[0], &DEFAULT_NORMALIZATION[32])).abs() < 1e-9);
         assert!((inp[33] - apply_norm(dv[1], &DEFAULT_NORMALIZATION[33])).abs() < 1e-9);
@@ -591,13 +646,15 @@ mod tests {
             &mut state,
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         let expected = bias0.atan2(bias1); // PI/4
         assert_relative_eq!(bank, expected, epsilon = 1e-12);
@@ -619,13 +676,15 @@ mod tests {
             &mut state,
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         assert_relative_eq!(bank, 0.5_f64.atan2(0.5), epsilon = 1e-12);
     }
@@ -645,13 +704,15 @@ mod tests {
             &mut state,
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         assert_relative_eq!(bank, (-1.0_f64).atan2(1.0), epsilon = 1e-12);
     }
@@ -717,13 +778,15 @@ mod tests {
             &mut state,
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
 
         assert!(bank.is_finite(), "bank angle must be finite, got: {}", bank);
@@ -800,13 +863,15 @@ mod tests {
             &mut state,
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
 
         assert!(bank.is_finite(), "bank angle must be finite, got: {bank}");
@@ -856,13 +921,15 @@ mod tests {
             &mut state,
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            -50.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: -50.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
 
         assert!(
@@ -916,18 +983,22 @@ mod tests {
         let full_mask: Vec<usize> = (0..21).collect();
         let full_input = build_nn_input(
             &nav,
-            Some(&full_mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&full_mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            target_inc,
-            ref_velocity,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: target_inc,
+                ref_velocity_latched: ref_velocity,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         let x0 = full_input[0];
         let x8 = full_input[8];
@@ -944,13 +1015,15 @@ mod tests {
             &mut state,
             &data,
             &planet,
-            target_inc,
-            ref_velocity,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: target_inc,
+                ref_velocity_latched: ref_velocity,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
 
         assert!(
@@ -1023,13 +1096,15 @@ mod tests {
             &mut state_normal,
             &data,
             &planet,
-            target_inc,
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: target_inc,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         let bank_ablated = nn_bank_angle(
             &nav,
@@ -1037,13 +1112,15 @@ mod tests {
             &mut state_ablated,
             &data,
             &planet,
-            target_inc,
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: target_inc,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
 
         // Ablated version zeros input 0, so output[0] = 0.0, bank = atan2(0, 1) = 0
@@ -1087,13 +1164,15 @@ mod tests {
             &mut state,
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
 
         assert!(bank.is_finite(), "bank must be finite, got: {bank}");
@@ -1138,20 +1217,12 @@ mod tests {
         let data = test_sim_data_with_ref_traj();
         let planet = PlanetConfig::mars();
         let mut state = NnState::for_model(&nn);
-        let bank = nn_bank_angle(
-            &nav,
-            &nn,
-            &mut state,
-            &data,
-            &planet,
-            50.0_f64.to_radians(),
-            0.0, // ref_velocity_latched = 0 pre-bounce,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-        );
+        let ctx = NnInputContext {
+            target_inclination: 50.0_f64.to_radians(),
+            ref_velocity_latched: 0.0, // = 0 pre-bounce
+            ..Default::default()
+        };
+        let bank = nn_bank_angle(&nav, &nn, &mut state, &data, &planet, &ctx);
 
         assert!(
             bank.is_finite(),
@@ -1172,18 +1243,15 @@ mod tests {
         let full_mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let inp = build_nn_input(
             &nav,
-            Some(&full_mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&full_mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None, // first-tick: no prev incl err
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext { target_inclination: 50.0_f64.to_radians(), ref_velocity_latched: 0.0, prev_inclination_error: None, prev_bank_signed: // first-tick: no prev incl err
+            0.0, time_since_last_sign_flip: 0.0, inclination_error_integral: 0.0, prev_realized_bank: 0.0 },
         );
         assert_eq!(inp[21], 0.0, "first-tick rate must be 0.0, got {}", inp[21]);
     }
@@ -1215,18 +1283,22 @@ mod tests {
         let full_mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let inp = build_nn_input(
             &nav,
-            Some(&full_mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&full_mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            target,
-            0.0,
-            Some(prev_err),
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: target,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(prev_err),
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         let expected = target_rate.to_degrees() * 10.0;
         assert_relative_eq!(inp[21], expected, epsilon = 1e-12);
@@ -1249,18 +1321,22 @@ mod tests {
         for (prev_bank, expected) in cases {
             let inp = build_nn_input(
                 &nav,
-                Some(&full_mask),
-                None,
-                0.0,
+                NnModelView {
+                    input_mask: Some(&full_mask),
+                    ablated_input: None,
+                    ablated_value: 0.0,
+                },
                 &data,
                 &planet,
-                target,
-                0.0,
-                None,
-                prev_bank,
-                0.0,
-                0.0,
-                0.0,
+                &NnInputContext {
+                    target_inclination: target,
+                    ref_velocity_latched: 0.0,
+                    prev_inclination_error: None,
+                    prev_bank_signed: prev_bank,
+                    time_since_last_sign_flip: 0.0,
+                    inclination_error_integral: 0.0,
+                    prev_realized_bank: 0.0,
+                },
             );
             assert_relative_eq!(inp[22], expected, epsilon = 1e-15);
         }
@@ -1278,18 +1354,22 @@ mod tests {
         for (t_since, expected) in cases {
             let inp = build_nn_input(
                 &nav,
-                Some(&full_mask),
-                None,
-                0.0,
+                NnModelView {
+                    input_mask: Some(&full_mask),
+                    ablated_input: None,
+                    ablated_value: 0.0,
+                },
                 &data,
                 &planet,
-                target,
-                0.0,
-                None,
-                0.0,
-                t_since,
-                0.0,
-                0.0,
+                &NnInputContext {
+                    target_inclination: target,
+                    ref_velocity_latched: 0.0,
+                    prev_inclination_error: None,
+                    prev_bank_signed: 0.0,
+                    time_since_last_sign_flip: t_since,
+                    inclination_error_integral: 0.0,
+                    prev_realized_bank: 0.0,
+                },
             );
             assert_relative_eq!(inp[23], expected, epsilon = 1e-10);
         }
@@ -1307,36 +1387,44 @@ mod tests {
         let integral_rad_s = 100.0_f64.to_radians(); // 100 deg·s in rad·s
         let inp = build_nn_input(
             &nav,
-            Some(&full_mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&full_mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            target,
-            0.0,
-            None,
-            0.0,
-            0.0,
-            integral_rad_s,
-            0.0,
+            &NnInputContext {
+                target_inclination: target,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: integral_rad_s,
+                prev_realized_bank: 0.0,
+            },
         );
         assert_relative_eq!(inp[24], 1.0_f64.tanh(), epsilon = 1e-12);
 
         // Negative integral → negative output (tanh is antisymmetric).
         let inp_neg = build_nn_input(
             &nav,
-            Some(&full_mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&full_mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            target,
-            0.0,
-            None,
-            0.0,
-            0.0,
-            -integral_rad_s,
-            0.0,
+            &NnInputContext {
+                target_inclination: target,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: -integral_rad_s,
+                prev_realized_bank: 0.0,
+            },
         );
         assert_relative_eq!(inp_neg[24], -1.0_f64.tanh(), epsilon = 1e-12);
     }
@@ -1355,33 +1443,34 @@ mod tests {
 
         let inp_a = build_nn_input(
             &nav,
-            Some(&mask_21),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&mask_21),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            target,
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: target,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         let inp_b = build_nn_input(
             &nav,
-            Some(&mask_21),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&mask_21),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            target,
-            0.0,
-            Some(0.1234), // arbitrary non-zero
-            std::f64::consts::PI,
-            42.5,
-            std::f64::consts::E,
-            0.0,
+            &NnInputContext { target_inclination: target, ref_velocity_latched: 0.0, prev_inclination_error: Some(0.1234), prev_bank_signed: // arbitrary non-zero
+            std::f64::consts::PI, time_since_last_sign_flip: 42.5, inclination_error_integral: std::f64::consts::E, prev_realized_bank: 0.0 },
         );
         assert_eq!(inp_a.len(), 21);
         assert_eq!(inp_b.len(), 21);
@@ -1400,18 +1489,14 @@ mod tests {
         // A wild prev_realized (9.9 rad) must never leak into the default [..16] slice.
         let v = build_nn_input(
             &nav,
-            None,
-            None,
-            0.0,
+            NnModelView {
+                input_mask: None,
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.3,
-            0.0,
-            0.0,
-            /*prev_realized*/ 9.9,
+            &NnInputContext { target_inclination: 0.0, ref_velocity_latched: 0.0, prev_inclination_error: Some(0.0), prev_bank_signed: 0.3, time_since_last_sign_flip: 0.0, inclination_error_integral: 0.0, prev_realized_bank: /*prev_realized*/ 9.9 },
         );
         assert_eq!(v.len(), 16, "default mask must return exactly 16 inputs");
         assert!(
@@ -1429,18 +1514,22 @@ mod tests {
         let mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let v = build_nn_input(
             &nav,
-            Some(&mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.3,
-            0.0,
-            0.0,
-            prev_realized,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.3,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: prev_realized,
+            },
         );
         assert_eq!(v.len(), NN_FULL_INPUT_SIZE);
         // sin at index 29, cos at index 30 — atan2(sin, cos) must recover the angle.
@@ -1482,13 +1571,15 @@ mod tests {
             &mut st,
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         assert_relative_eq!(b, 0.0, epsilon = 1e-12);
         assert!(
@@ -1535,13 +1626,15 @@ mod tests {
             &mut st,
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         let unwrapped = 1.5 * PI * bias.tanh();
         let expected = wrap_to_pi(unwrapped);
@@ -1596,13 +1689,15 @@ mod tests {
             &mut st,
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.0,
-            0.0,
-            0.0,
-            prev_realized,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: prev_realized,
+            },
         );
         let expected_raw = prev_realized + 0.2 * 5.0_f64.tanh();
         assert!(
@@ -1655,13 +1750,15 @@ mod tests {
             &mut st,
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.0,
-            0.0,
-            0.0,
-            prev_realized,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: prev_realized,
+            },
         );
         let expected = wrap_to_pi(prev_realized + 0.5 * bias.tanh());
         assert!(
@@ -1714,40 +1811,34 @@ mod tests {
         }
 
         proptest! {
-                    #[test]
-                    fn output_always_finite(
-                        alt in 10_000.0..130_000.0_f64,
-                        vel in 2000.0..7000.0_f64,
-                        fpa in -0.3..0.05_f64,
-                        az  in -1.0..1.0_f64,
-                    ) {
-                        let r = PlanetConfig::mars().equatorial_radius + alt;
-                        let nav = NavigationOutput {
-                            position_estimated: [r, 0.1, 0.05],
-                            velocity_estimated: [vel, fpa, az],
-                            acceleration_estimated: [50.0, -8.0],
-                            aero_coefficients: [1.269, -0.205],
-                            density_guidance: 0.001,
-                            dynamic_pressure_estimated: 0.5 * 0.001 * vel * vel,
-                            energy_estimated: -1e6,
-                            ..Default::default()
-                        };
+            #[test]
+            fn output_always_finite(
+                alt in 10_000.0..130_000.0_f64,
+                vel in 2000.0..7000.0_f64,
+                fpa in -0.3..0.05_f64,
+                az  in -1.0..1.0_f64,
+            ) {
+                let r = PlanetConfig::mars().equatorial_radius + alt;
+                let nav = NavigationOutput {
+                    position_estimated: [r, 0.1, 0.05],
+                    velocity_estimated: [vel, fpa, az],
+                    acceleration_estimated: [50.0, -8.0],
+                    aero_coefficients: [1.269, -0.205],
+                    density_guidance: 0.001,
+                    dynamic_pressure_estimated: 0.5 * 0.001 * vel * vel,
+                    energy_estimated: -1e6,
+                    ..Default::default()
+                };
 
-                        let nn = fixed_small_nn();
-                        let data = test_sim_data();
-                        let planet = PlanetConfig::mars();
-                        let mut state = NnState::for_model(&nn);
-                        let bank = nn_bank_angle(&nav, &nn, &mut state, &data, &planet, 50.0_f64.to_radians(), 0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-        );
+                let nn = fixed_small_nn();
+                let data = test_sim_data();
+                let planet = PlanetConfig::mars();
+                let mut state = NnState::for_model(&nn);
+                let bank = nn_bank_angle(&nav, &nn, &mut state, &data, &planet, &NnInputContext { target_inclination: 50.0_f64.to_radians(), ref_velocity_latched: 0.0, prev_inclination_error: None, prev_bank_signed: 0.0, time_since_last_sign_flip: 0.0, inclination_error_integral: 0.0, prev_realized_bank: 0.0 });
 
-                        prop_assert!(bank.is_finite(), "bank not finite: {}", bank);
-                    }
-                }
+                prop_assert!(bank.is_finite(), "bank not finite: {}", bank);
+            }
+        }
 
         #[test]
         fn acos_tanh_parameterization_emits_acos_of_output() {
@@ -1787,13 +1878,15 @@ mod tests {
                 &mut state,
                 &data,
                 &planet,
-                50.0_f64.to_radians(),
-                0.0,
-                None,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
+                &NnInputContext {
+                    target_inclination: 50.0_f64.to_radians(),
+                    ref_velocity_latched: 0.0,
+                    prev_inclination_error: None,
+                    prev_bank_signed: 0.0,
+                    time_since_last_sign_flip: 0.0,
+                    inclination_error_integral: 0.0,
+                    prev_realized_bank: 0.0,
+                },
             );
 
             let expected = (0.5_f64).tanh().acos();
@@ -1819,18 +1912,22 @@ mod tests {
         let mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let v = build_nn_input(
             &nav,
-            Some(&mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.3,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.3,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         assert_eq!(v.len(), NN_FULL_INPUT_SIZE);
         assert!(v.iter().all(|x| x.is_finite()));
@@ -1852,18 +1949,22 @@ mod tests {
         // freeze index 2 to 0.7
         let v = build_nn_input(
             &nav,
-            Some(&mask),
-            Some(2),
-            0.7,
+            NnModelView {
+                input_mask: Some(&mask),
+                ablated_input: Some(2),
+                ablated_value: 0.7,
+            },
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.3,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.3,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         assert!((v[2] - 0.7).abs() < 1e-12);
     }
@@ -1876,18 +1977,22 @@ mod tests {
         let mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let v = build_nn_input(
             &nav,
-            Some(&mask),
-            Some(2),
-            0.0,
+            NnModelView {
+                input_mask: Some(&mask),
+                ablated_input: Some(2),
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.3,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.3,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         assert_eq!(v[2], 0.0);
     }
@@ -1899,18 +2004,22 @@ mod tests {
         let planet = PlanetConfig::mars();
         let v = build_nn_input(
             &nav,
-            None,
-            None,
-            0.0,
+            NnModelView {
+                input_mask: None,
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.3,
-            0.0,
-            0.0,
-            9.9,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.3,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 9.9,
+            },
         );
         assert_eq!(v.len(), 16);
     }
@@ -1923,18 +2032,22 @@ mod tests {
         let mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let v = build_nn_input(
             &nav,
-            Some(&mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.3,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.3,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         use crate::data::neural::{DEFAULT_NORMALIZATION, apply_norm};
         let velocity_radial = nav.velocity_estimated[0] * nav.velocity_estimated[1].sin();
@@ -1954,18 +2067,22 @@ mod tests {
         let mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let v = build_nn_input(
             &nav,
-            Some(&mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.3,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.3,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         // Recompute pdyn_error the same way build_nn_input does.
         let energy = total_energy(
@@ -1999,18 +2116,22 @@ mod tests {
         let mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let v = build_nn_input(
             &nav,
-            Some(&mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            0.0,
-            0.0,
-            Some(0.0),
-            0.3,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 0.0,
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: Some(0.0),
+                prev_bank_signed: 0.3,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         let orbit = elements::from_spherical(
             nav.position_estimated[0],
@@ -2067,18 +2188,22 @@ mod tests {
         let mask: Vec<usize> = (0..NN_FULL_INPUT_SIZE).collect();
         let inp = build_nn_input(
             &nav,
-            Some(&mask),
-            None,
-            0.0,
+            NnModelView {
+                input_mask: Some(&mask),
+                ablated_input: None,
+                ablated_value: 0.0,
+            },
             &data,
             &planet,
-            50.0_f64.to_radians(),
-            0.0,
-            None,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            &NnInputContext {
+                target_inclination: 50.0_f64.to_radians(),
+                ref_velocity_latched: 0.0,
+                prev_inclination_error: None,
+                prev_bank_signed: 0.0,
+                time_since_last_sign_flip: 0.0,
+                inclination_error_integral: 0.0,
+                prev_realized_bank: 0.0,
+            },
         );
         for (idx, &val) in inp.iter().enumerate().skip(32).take(3) {
             assert!(val.is_finite(), "input[{idx}] = {val} must be finite");
@@ -2182,18 +2307,22 @@ mod tests {
             nav.velocity_estimated[0] *= scale_v;
             let inp = build_nn_input(
                 &nav,
-                Some(&full_mask),
-                None,
-                0.0,
+                NnModelView {
+                    input_mask: Some(&full_mask),
+                    ablated_input: None,
+                    ablated_value: 0.0,
+                },
                 &data,
                 &planet,
-                50.0_f64.to_radians(),
-                0.0,
-                Some(0.01),
-                0.2,
-                12.0,
-                3.0,
-                0.15,
+                &NnInputContext {
+                    target_inclination: 50.0_f64.to_radians(),
+                    ref_velocity_latched: 0.0,
+                    prev_inclination_error: Some(0.01),
+                    prev_bank_signed: 0.2,
+                    time_since_last_sign_flip: 12.0,
+                    inclination_error_integral: 3.0,
+                    prev_realized_bank: 0.15,
+                },
             );
             for i in 0..32 {
                 assert!(

--- a/src/rust/src/simulation/tick.rs
+++ b/src/rust/src/simulation/tick.rs
@@ -165,25 +165,20 @@ pub fn step_one_tick(
             // Explicit full mask: select ALL candidate inputs (NN_FULL_INPUT_SIZE wide).
             // Passing None would trigger the backward-compat default (first 16 only).
             let full_mask: Vec<usize> = (0..crate::data::neural::NN_FULL_INPUT_SIZE).collect();
-            // Telemetry scalars sourced from GuidanceState -- these reflect the
+            // Telemetry context sourced from GuidanceState -- it reflects the
             // PREVIOUS-tick state (updated below after guidance_step), keeping
             // the supervised collect's input vector consistent with deploy.
-            let time_since_flip = state.sim_time - state.guidance_state.last_sign_flip_time_for_nn;
-            let nn_input = crate::gnc::guidance::neural::build_nn_input(
-                &nav_out,
-                Some(&full_mask),
-                None, // no ablation
-                0.0,  // ablated_value (unused when ablated_input is None)
-                data,
-                planet,
+            let ctx = crate::gnc::guidance::neural::NnInputContext::from_guidance_state(
+                &state.guidance_state,
+                state.sim_time,
                 data.target_orbit.inclination,
-                state.guidance_state.reference_velocity,
-                state.guidance_state.prev_inclination_error_for_nn,
-                state.guidance_state.prev_bank_for_nn,
-                time_since_flip,
-                state.guidance_state.inclination_error_integral,
-                state.guidance_state.prev_realized_bank_for_nn,
             );
+            let view = crate::gnc::guidance::neural::NnModelView {
+                input_mask: Some(&full_mask),
+                ..Default::default() // no ablation
+            };
+            let nn_input =
+                crate::gnc::guidance::neural::build_nn_input(&nav_out, view, data, planet, &ctx);
             // Supervised target is the post-lateral, PRE-shaper signed bank.
             // - Sign preserved: full_neural deploy has no lateral guidance at
             //   runtime, so the NN must emit signed banks itself; the signed


### PR DESCRIPTION
**Stack position 11/11.** Review order follows the architecture-review index (#80). Built on `feature/runner-single-fanout`; until that predecessor merges, this PR's diff also shows its commits -- merge top-down with merge commits and each PR collapses to its own change.

build_nn_input took 13 parameters and nn_bank_angle 12; the same five
GuidanceState telemetry fields (previous inclination error, previous
commanded bank, sign-flip time, inclination-error integral, previous
realized bank) were unpacked identically by the dispatcher, the supervised
trace recorder and the RL observation builder, and re-typed at ~40 test
call sites. Both functions carried a too_many_arguments allowance.

NnInputContext (Copy) holds the target inclination and that telemetry;
NnInputContext::from_guidance_state(gs, sim_time, target) is the one place
the sign-flip age is computed, and dispatch.rs, tick.rs and env.rs all go
through it, so RL observations keep tracking the policy's own previous
action. NnModelView (mask + ablation) replaces the three model-derived
arguments; NnModelView::of(model) reads them from a loaded model. Test calls
use struct literals with ..Default::default(). No arithmetic changed.

Gates: Rust release suite incl. the six guidance goldens, PyO3-vs-CLI and
run_grid bit-identity, collect_supervised / collect_nn_inputs traces,
cross-language equivalence, the RL env tests, the fast Python suite.

Closes #79

(Second commit on this branch: the one-line CLAUDE.md re-wrap the #79 sync pushed past 200 bytes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)