### PR TITLE
Agent policy: gh may push branches and open PRs; merging stays with the user

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 # Issue tracker: GitHub
 
-> **Scope note:** the user's global instructions ban the `gh` CLI generally. Issue-tracker operations in this repo are an explicit exception, chosen during setup on 2026-08-26. The ban still applies to PR creation and other GitHub operations.
+> **Scope note:** in this repo the `gh` CLI is allowed for issue-tracker operations (chosen during setup on 2026-08-26), and since 2026-09-04 also for pushing feature branches (`git push`, never force, never to `main`) and for creating, editing, viewing and commenting on pull requests and their CI checks. **Merging is the user's alone**: never `gh pr merge`, never a merge API call, never a push to `main`. The permission rules in `.claude/settings.json` encode exactly this (allow list + deny list); everything else on GitHub still prompts.
 
 Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
 


### PR DESCRIPTION
Independent of the architecture-review stack (docs only, one line). Records the gh scope you granted on 2026-09-04 in the agent-facing policy doc so future sessions do not re-ask. The permission rules themselves are in `.claude/settings.json`, which `.gitignore` excludes -- say if you want that file un-ignored and committed.

The issue-tracker scope note said gh was banned for everything but issues.
The user widened it on 2026-09-04: pushing feature branches (never force,
never to main) and creating / editing / viewing / commenting on PRs and
their CI checks are allowed; merging (gh pr merge, merge API calls, pushes
to main) is never the agent's. The matching allow/deny lists live in the
gitignored .claude/settings.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)